### PR TITLE
Upgrade argument analyzer with semantic reasoning

### DIFF
--- a/MCP_example_template/arg_mcp/__init__.py
+++ b/MCP_example_template/arg_mcp/__init__.py
@@ -1,5 +1,5 @@
 from .ontology import Ontology, ToolCatalog, load_ontology, load_tool_catalog
-from .structures import ArgumentNode, ArgumentLink, NodeType, RelationshipType
+from .structures import ArgumentNode, ArgumentLink, NodeType, RelationshipType, NodePropertyAssigner
 from .patterns import PatternDetector, Pattern
 from .gap import GapAnalyzer, MissingAssumption
 from .probes import ProbeOrchestrator
@@ -14,6 +14,7 @@ __all__ = [
     "ArgumentLink",
     "NodeType",
     "RelationshipType",
+    "NodePropertyAssigner",
     "PatternDetector",
     "Pattern",
     "GapAnalyzer",

--- a/MCP_example_template/arg_mcp/gap.py
+++ b/MCP_example_template/arg_mcp/gap.py
@@ -1,83 +1,95 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Dict, Any
+from typing import List, Dict, Any, DefaultDict
 
 
 @dataclass
 class MissingAssumption:
     text: str
-    category: str  # e.g., Causal ID, Authority Preconditions, Analogy Preconditions
+    category: str
     rationale: str
     priority: str  # critical, testable, controversial, other
 
 
-class GapAnalyzer:
+class DynamicGapAnalyzer:
+    """Identify missing assumptions based on detected argument schemes."""
+
+    def __init__(self) -> None:
+        self.templates: Dict[str, List[MissingAssumption]] = {
+            "Argument from Expert Opinion": [
+                MissingAssumption(
+                    text="Expertise relevance and scope alignment",
+                    category="Authority Preconditions",
+                    rationale="Expert’s domain should match the claim’s scope.",
+                    priority="critical",
+                ),
+                MissingAssumption(
+                    text="Bias and conflict-of-interest checked",
+                    category="Authority Preconditions",
+                    rationale="Funding/affiliations may undercut credibility.",
+                    priority="testable",
+                ),
+                MissingAssumption(
+                    text="Consensus and replication status known",
+                    category="Authority Preconditions",
+                    rationale="Single testimony is weaker than replicated consensus.",
+                    priority="controversial",
+                ),
+            ],
+            "Argument from Cause to Effect": [
+                MissingAssumption(
+                    text="No simultaneity or reverse causation",
+                    category="Causal ID",
+                    rationale="Causal phrasing implies temporal precedence and one-way influence.",
+                    priority="critical",
+                ),
+                MissingAssumption(
+                    text="Unmeasured confounding ruled out",
+                    category="Causal ID",
+                    rationale="Association could be driven by omitted variables; require design or control.",
+                    priority="critical",
+                ),
+                MissingAssumption(
+                    text="Mechanism plausibility or pathway specified",
+                    category="Mechanistic",
+                    rationale="Bridges cause to effect; improves transportability and diagnosis of failures.",
+                    priority="testable",
+                ),
+            ],
+            "Argument from Analogy": [
+                MissingAssumption(
+                    text="Similarity dimensions specified and relevant",
+                    category="Analogy Preconditions",
+                    rationale="Analogy requires shared, problem-relevant properties.",
+                    priority="critical",
+                ),
+                MissingAssumption(
+                    text="Scope and limits of analogy stated",
+                    category="Analogy Preconditions",
+                    rationale="Prevents over-generalization beyond justified range.",
+                    priority="testable",
+                ),
+            ],
+            "Practical Reasoning": [
+                MissingAssumption(
+                    text="Goals, constraints, and trade-offs explicit",
+                    category="Practical Reasoning",
+                    rationale="Action claims depend on prioritized values and constraints.",
+                    priority="critical",
+                ),
+            ],
+        }
+
     def analyze(self, patterns: List[Dict[str, Any]]) -> List[MissingAssumption]:
+        schemes = {p.get("details", {}).get("scheme") or p.get("label") for p in patterns}
         out: List[MissingAssumption] = []
-        types = {p.get("pattern_type") for p in patterns}
-
-        if "causal" in types:
-            out.append(MissingAssumption(
-                text="No Simultaneity/Reverse Causation",
-                category="Causal ID",
-                rationale="Causal phrasing implies temporal precedence and one-way influence.",
-                priority="critical",
-            ))
-            out.append(MissingAssumption(
-                text="Unmeasured Confounding controlled or ruled out",
-                category="Causal ID",
-                rationale="Association could be driven by omitted variables; require design or control.",
-                priority="critical",
-            ))
-            out.append(MissingAssumption(
-                text="Mechanism plausibility or pathway specified",
-                category="Mechanistic",
-                rationale="Bridges cause to effect; improves transportability and diagnosis of failures.",
-                priority="testable",
-            ))
-
-        if "authority" in types:
-            out.append(MissingAssumption(
-                text="Expertise relevance and scope alignment",
-                category="Authority Preconditions",
-                rationale="Expert’s domain should match the claim’s scope.",
-                priority="critical",
-            ))
-            out.append(MissingAssumption(
-                text="Bias and conflict-of-interest checked",
-                category="Authority Preconditions",
-                rationale="Funding/affiliations may undercut credibility.",
-                priority="testable",
-            ))
-            out.append(MissingAssumption(
-                text="Consensus and replication status known",
-                category="Authority Preconditions",
-                rationale="Single testimony is weaker than replicated consensus.",
-                priority="controversial",
-            ))
-
-        if "analogical" in types:
-            out.append(MissingAssumption(
-                text="Similarity dimensions specified and relevant",
-                category="Analogy Preconditions",
-                rationale="Analogy requires shared, problem-relevant properties.",
-                priority="critical",
-            ))
-            out.append(MissingAssumption(
-                text="Scope and limits of analogy stated",
-                category="Analogy Preconditions",
-                rationale="Prevents over-generalization beyond justified range.",
-                priority="testable",
-            ))
-
-        if "normative" in types:
-            out.append(MissingAssumption(
-                text="Goals, constraints, and trade-offs explicit",
-                category="Practical Reasoning",
-                rationale="Action claims depend on prioritized values and constraints.",
-                priority="critical",
-            ))
-
+        for s in schemes:
+            for tpl in self.templates.get(s, []):
+                out.append(tpl)
         return out
+
+
+# Backwards compatibility export
+GapAnalyzer = DynamicGapAnalyzer
 

--- a/MCP_example_template/arg_mcp/ontology.py
+++ b/MCP_example_template/arg_mcp/ontology.py
@@ -6,6 +6,9 @@ import csv
 import os
 import math
 
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
 
 @dataclass
 class OntologyRow:
@@ -58,6 +61,15 @@ class Ontology:
                 self._bucket_index.setdefault(bkey, []).append(r)
             self._dim_index.setdefault(r.dimension, []).append(r)
 
+        # Pre-compute TF-IDF embeddings for semantic similarity
+        corpus = [" ".join([r.dimension, r.category, r.bucket, r.description, r.example, r.note]) for r in rows]
+        if corpus:
+            self._vectorizer = TfidfVectorizer().fit(corpus)
+            self._matrix = self._vectorizer.transform(corpus)
+        else:
+            self._vectorizer = TfidfVectorizer().fit([""])
+            self._matrix = self._vectorizer.transform([""])
+
     def list_dimensions(self) -> List[str]:
         return self.dimensions
 
@@ -108,34 +120,24 @@ class Ontology:
                 })
         return out
 
-    # Lightweight semantic similarity using normalized token Jaccard and TF scoring
-    def semantic_search(self, query: str, dimensions: Optional[List[str]] = None, threshold: float = 0.2, max_results: int = 10) -> List[Dict[str, Any]]:
-        def tokens(s: str) -> List[str]:
-            return [t for t in _normalize(s).replace("–","-").replace("—","-").replace(","," ").replace("."," ").split() if t]
-
-        q_tokens = tokens(query)
-        q_set = set(q_tokens)
+    # Semantic similarity using TF-IDF cosine similarity
+    def semantic_search(
+        self,
+        query: str,
+        dimensions: Optional[List[str]] = None,
+        threshold: float = 0.2,
+        max_results: int = 10,
+    ) -> List[Dict[str, Any]]:
+        if not query.strip():
+            return []
+        vec = self._vectorizer.transform([query])
+        sims = cosine_similarity(vec, self._matrix)[0]
         results: List[Tuple[float, OntologyRow]] = []
-        for r in self.rows:
-            if dimensions and r.dimension not in dimensions:
+        for score, row in zip(sims, self.rows):
+            if dimensions and row.dimension not in dimensions:
                 continue
-            blob = " ".join([r.dimension, r.category, r.bucket, r.description, r.example, r.note])
-            tks = tokens(blob)
-            tset = set(tks)
-            if not tset:
-                continue
-            inter = len(q_set & tset)
-            uni = len(q_set | tset)
-            jacc = inter / uni if uni else 0.0
-            # simple TF weighting: more matches in bucket/description boosts score
-            score = jacc
-            if inter:
-                if _normalize(r.bucket) in q_set:
-                    score += 0.1
-                if any(t in _normalize(r.description) for t in q_set):
-                    score += 0.05
             if score >= threshold:
-                results.append((score, r))
+                results.append((float(score), row))
         results.sort(key=lambda x: x[0], reverse=True)
         out: List[Dict[str, Any]] = []
         for score, r in results[:max_results]:

--- a/MCP_example_template/arg_mcp/patterns.py
+++ b/MCP_example_template/arg_mcp/patterns.py
@@ -2,50 +2,74 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Any, Tuple
-import re
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from .ontology import Ontology, OntologyRow
 
 
 @dataclass
 class Pattern:
     pattern_id: str
-    pattern_type: str  # causal, authority, analogical, normative, quantifier, temporal, statistical, definition
+    pattern_type: str  # causal, authority, analogical, normative, etc.
     label: str
     span: Optional[Tuple[int, int]]
     confidence: float
     details: Dict[str, Any]
 
 
-class PatternDetector:
-    def __init__(self) -> None:
-        # Compile regex for core patterns with some paraphrase coverage
-        self.re_causal = re.compile(r"\b(because|since|leads to|results in|due to|therefore|thus|so that|causes?)\b", re.I)
-        self.re_authority = re.compile(r"\b(experts? (say|agree)|studies? (show|find)|researchers?|doctor|dr\.|prof(essor)?|according to)\b", re.I)
-        self.re_analogical = re.compile(r"\b(like|similar to|analog(ous)?|as if|just as)\b", re.I)
-        self.re_normative = re.compile(r"\b(should|ought to|must|need to|the best way|we should)\b", re.I)
-        self.re_quantifier = re.compile(r"\b(always|never|everyone|no one|all|none|most|many|few)\b", re.I)
-        self.re_temporal = re.compile(r"\b(before|after|until|while|prior to|subsequently|eventually|now)\b", re.I)
-        self.re_statistical = re.compile(r"\b(percent|%|p-value|statistical(ly)? significant|correlat(es|ion)|regression|sample|random|control group)\b", re.I)
-        self.re_definition = re.compile(r"\b(defines? as|means that|by definition|we call|is defined as)\b", re.I)
+class EnhancedPatternDetector:
+    """Semantic pattern detector using ontology descriptions instead of regex."""
 
-    def _scan(self, text: str, kind: str, regex: re.Pattern, label: str) -> List[Pattern]:
-        out: List[Pattern] = []
-        for m in regex.finditer(text):
-            conf = 0.7
-            if kind in ("quantifier", "temporal"):
-                conf = 0.5
-            out.append(Pattern(pattern_id=f"pat_{m.start()}_{m.end()}", pattern_type=kind, label=label, span=(m.start(), m.end()), confidence=conf, details={"match": m.group(0)}))
-        return out
+    def __init__(self, ontology: Ontology) -> None:
+        self.ontology = ontology
+        self.scheme_rows: List[OntologyRow] = [r for r in ontology.rows if r.dimension == "Argument Scheme"]
+        corpus = [" ".join([r.category, r.bucket, r.description, r.example]) for r in self.scheme_rows]
+        if corpus:
+            self.vectorizer = TfidfVectorizer().fit(corpus)
+            self.matrix = self.vectorizer.transform(corpus)
+        else:
+            self.vectorizer = TfidfVectorizer().fit([""])
+            self.matrix = self.vectorizer.transform([""])
+
+    def _map_pattern_type(self, row: OntologyRow) -> str:
+        cat = f"{row.category} {row.bucket}".lower()
+        if "cause" in cat or "consequence" in cat:
+            return "causal"
+        if "expert" in cat or "authority" in cat or "testimony" in cat:
+            return "authority"
+        if "analog" in cat:
+            return "analogical"
+        if "practical" in cat or "policy" in cat:
+            return "normative"
+        return "other"
 
     def detect(self, text: str) -> List[Pattern]:
-        L = text
-        pats: List[Pattern] = []
-        pats += self._scan(L, "causal", self.re_causal, "Causal Indicator")
-        pats += self._scan(L, "authority", self.re_authority, "Authority Marker")
-        pats += self._scan(L, "analogical", self.re_analogical, "Analogical Language")
-        pats += self._scan(L, "normative", self.re_normative, "Normative/Practical")
-        pats += self._scan(L, "quantifier", self.re_quantifier, "Quantifier/Generality")
-        pats += self._scan(L, "temporal", self.re_temporal, "Temporal Cue")
-        pats += self._scan(L, "statistical", self.re_statistical, "Statistical/Evidence Cue")
-        pats += self._scan(L, "definition", self.re_definition, "Definition/Category Cue")
-        return pats
+        if not text.strip():
+            return []
+        vec = self.vectorizer.transform([text])
+        sims = cosine_similarity(vec, self.matrix)[0]
+        out: List[Pattern] = []
+        for i, score in enumerate(sims):
+            if score <= 0:
+                continue
+            row = self.scheme_rows[i]
+            ptype = self._map_pattern_type(row)
+            out.append(
+                Pattern(
+                    pattern_id=f"scheme_{i}",
+                    pattern_type=ptype,
+                    label=row.category,
+                    span=None,
+                    confidence=float(score),
+                    details={"scheme": row.category, "score": float(score)},
+                )
+            )
+        out.sort(key=lambda p: p.confidence, reverse=True)
+        return out[:10]
+
+
+# Backwards compatibility export
+PatternDetector = EnhancedPatternDetector
 

--- a/MCP_example_template/arg_mcp/probes.py
+++ b/MCP_example_template/arg_mcp/probes.py
@@ -66,12 +66,24 @@ class ProbeOrchestrator:
         return order + rest
 
     def chain_probes_conditionally(self, initial_findings: Dict[str, Any]) -> List[Dict[str, Any]]:
-        # Returns a simple chain (sequence) of probe suggestions with rationale
+        # Build a conditional chain of probe suggestions
         patterns = initial_findings.get("patterns", [])
         probes = self.select_probes_by_pattern(patterns)
-        ranked = self.prioritize_by_context(probes, initial_findings.get("forum"), initial_findings.get("audience"), initial_findings.get("goal"))
+        ranked = self.prioritize_by_context(
+            probes,
+            initial_findings.get("forum"),
+            initial_findings.get("audience"),
+            initial_findings.get("goal"),
+        )
         sequence: List[Dict[str, Any]] = []
+        prev: Optional[str] = None
         for p in ranked:
-            sequence.append({"tool": p, "when": "initial", "rationale": "Selected by detected pattern and forum weighting."})
+            step = {
+                "tool": p,
+                "when": "after " + prev if prev else "initial",
+                "rationale": "Selected by detected pattern and forum weighting.",
+            }
+            sequence.append(step)
+            prev = p["name"]
         return sequence
 


### PR DESCRIPTION
## Summary
- replace regex pattern detection with TF-IDF semantic scheme matcher
- introduce dynamic gap templates keyed to detected argument schemes
- add ontology-driven node property assignment and iterative cross-validation
- use TF-IDF ontology embeddings and conditional probe chains

## Testing
- `python - <<'PY'
from MCP_example_template.arg_mcp import load_ontology, Ontology, load_tool_catalog, ToolCatalog, AnalysisEngine, AnalysisContext
import os
workdir='.'
onto=Ontology(load_ontology(os.path.join(workdir,'new_argumentation_database_buckets_fixed.csv')))
tools=ToolCatalog(load_tool_catalog(os.path.join(workdir,'argument_tools.csv')))
engine=AnalysisEngine(onto, tools)
text="Experts say that smoking causes cancer because studies show strong evidence. Therefore, governments should regulate tobacco."
res=engine.analyze_comprehensive(text, AnalysisContext(forum='policy'))
print('Patterns count', len(res['patterns']))
print('Assumptions', res['assumptions'])
print('Main reasoning pattern', [n for n in res['structure']['nodes'] if n['primary_subtype']=='Main Claim'][0]['reasoning_pattern'])
print('Probes chain:', [f"{step['tool']['name']} ({step['when']})" for step in res['probes']])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c5e9677828832d9bee7f24f21db27b