### PR TITLE
Upgrade argument analyzer with semantic reasoning

### DIFF
--- a/MCP_example_template/arg_mcp/__init__.py
+++ b/MCP_example_template/arg_mcp/__init__.py
@@ -1,7 +1,7 @@
 from .ontology import Ontology, ToolCatalog, load_ontology, load_tool_catalog
-from .structures import ArgumentNode, ArgumentLink, NodeType, RelationshipType
+from .structures import ArgumentNode, ArgumentLink, NodeType, RelationshipType, NodePropertyAssigner
 from .patterns import PatternDetector, Pattern
-from .gap import GapAnalyzer, MissingAssumption
+from .gap import InferenceEngine, RequirementResult, SchemeEvaluation
 from .probes import ProbeOrchestrator
 from .engine import AnalysisEngine, AnalysisContext
 
@@ -14,10 +14,12 @@ __all__ = [
     "ArgumentLink",
     "NodeType",
     "RelationshipType",
+    "NodePropertyAssigner",
     "PatternDetector",
     "Pattern",
-    "GapAnalyzer",
-    "MissingAssumption",
+    "InferenceEngine",
+    "RequirementResult",
+    "SchemeEvaluation",
     "ProbeOrchestrator",
     "AnalysisEngine",
     "AnalysisContext",

--- a/MCP_example_template/arg_mcp/__init__.py
+++ b/MCP_example_template/arg_mcp/__init__.py
@@ -1,7 +1,7 @@
 from .ontology import Ontology, ToolCatalog, load_ontology, load_tool_catalog
 from .structures import ArgumentNode, ArgumentLink, NodeType, RelationshipType, NodePropertyAssigner
 from .patterns import PatternDetector, Pattern
-from .gap import InferenceEngine, RequirementResult, SchemeEvaluation
+from .gap import InferenceEngine, RequirementResult, SchemeEvaluation, GapAnalyzer
 from .probes import ProbeOrchestrator
 from .engine import AnalysisEngine, AnalysisContext
 
@@ -20,6 +20,7 @@ __all__ = [
     "InferenceEngine",
     "RequirementResult",
     "SchemeEvaluation",
+    "GapAnalyzer",
     "ProbeOrchestrator",
     "AnalysisEngine",
     "AnalysisContext",

--- a/MCP_example_template/arg_mcp/domain_profiles.py
+++ b/MCP_example_template/arg_mcp/domain_profiles.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Domain profiles that adapt requirement weights and probes."""
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class DomainProfile:
+    name: str
+    requirement_weights: Dict[str, float]
+    extra_requirements: Dict[str, List[str]]
+    preferred_probes: List[str]
+
+
+GENERAL_PROFILE = DomainProfile(
+    name="general",
+    requirement_weights={},
+    extra_requirements={},
+    preferred_probes=[],
+)
+
+LEGAL_PROFILE = DomainProfile(
+    name="legal",
+    requirement_weights={"precedent": 2.0, "burden_of_proof": 1.5},
+    extra_requirements={"authority": ["chain_of_authority"], "causal": ["statutory_link"]},
+    preferred_probes=["case_law_search"],
+)
+
+SCIENTIFIC_PROFILE = DomainProfile(
+    name="scientific",
+    requirement_weights={"methodology": 2.0, "replication": 1.5},
+    extra_requirements={"causal": ["statistical_power"]},
+    preferred_probes=["literature_search"],
+)
+
+POLICY_PROFILE = DomainProfile(
+    name="policy",
+    requirement_weights={"stakeholder": 1.5, "feasibility": 1.2},
+    extra_requirements={"practical": ["cost_benefit", "implementation_risk"]},
+    preferred_probes=["policy_database"],
+)
+
+PROFILES = {
+    p.name: p
+    for p in [GENERAL_PROFILE, LEGAL_PROFILE, SCIENTIFIC_PROFILE, POLICY_PROFILE]
+}

--- a/MCP_example_template/arg_mcp/engine.py
+++ b/MCP_example_template/arg_mcp/engine.py
@@ -4,11 +4,13 @@ from dataclasses import dataclass, asdict
 from typing import List, Dict, Any, Optional
 import re
 
-from .structures import ArgumentNode, ArgumentLink
+from .structures import ArgumentNode, ArgumentLink, NodePropertyAssigner, ArgumentGraph
 from .patterns import PatternDetector, Pattern
-from .gap import GapAnalyzer
+from .gap import InferenceEngine
 from .ontology import Ontology, ToolCatalog
 from .probes import ProbeOrchestrator
+from .domain_profiles import PROFILES, DomainProfile
+from .validation import check_factual_consistency, check_sentiment_coherence, check_plausibility
 
 
 @dataclass
@@ -23,9 +25,11 @@ class AnalysisEngine:
     def __init__(self, ontology: Ontology, tools: ToolCatalog) -> None:
         self.ontology = ontology
         self.tools = tools
-        self.detector = PatternDetector()
-        self.gap = GapAnalyzer()
+        self.detector = PatternDetector(ontology)
+        self.assigner = NodePropertyAssigner(ontology)
         self.probes = ProbeOrchestrator(tools)
+        self.profile: DomainProfile = PROFILES["general"]
+        self.infer = InferenceEngine(ontology, self.profile)
 
     # Stage 1: Structural Decomposition
     def stage1_decompose(self, text: str) -> Dict[str, Any]:
@@ -73,57 +77,117 @@ class AnalysisEngine:
     # Stage 2: Multi-Dimensional Pattern Recognition
     def stage2_patterns(self, text: str, nodes: List[Dict[str, Any]]) -> Dict[str, Any]:
         patterns = [asdict(p) for p in self.detector.detect(text)]
-        # Annotate nodes with coarse properties based on pattern coverage
         for n in nodes:
-            c = n.get("content", "")
-            c_l = c.lower()
-            if any(p["pattern_type"] == "normative" and self._span_in_text(p, text, c) for p in patterns):
-                n["reasoning_pattern"] = n.get("reasoning_pattern") or "Practical Reasoning"
-            if any(p["pattern_type"] == "causal" and self._span_in_text(p, text, c) for p in patterns):
-                n["reasoning_pattern"] = n.get("reasoning_pattern") or "Causal"
-            if re.search(r"\b(experts?|studies?|dr\.|prof)\b", c_l):
-                n["argument_scheme"] = n.get("argument_scheme") or "Argument from Expert Opinion"
-            if re.search(r"\b(like|similar to|analog)\b", c_l):
-                n["argument_scheme"] = n.get("argument_scheme") or "Argument from Analogy"
+            self.assigner.assign_comprehensive_properties(n, text, patterns)
         return {"patterns": patterns, "nodes": nodes}
 
     # Stage 3: Systematic Gap Analysis
-    def stage3_gaps(self, patterns: List[Dict[str, Any]], nodes: List[Dict[str, Any]]) -> Dict[str, Any]:
-        missing = self.gap.analyze(patterns)
-        # Attach assumptions to main claim if present, else to all nodes
-        main_candidates = [n for n in nodes if n.get("primary_subtype") == "Main Claim"] or nodes
-        for m in missing:
-            main_candidates[0].setdefault("assumptions", []).append(m.text)
-        return {"assumptions": [m.__dict__ for m in missing], "nodes": nodes}
+    def stage3_infer(self, text: str, patterns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        evaluations = []
+        assumptions = []
+        for p in patterns:
+            p = dict(p)
+            p.setdefault("scheme", p.get("details", {}).get("scheme") or p.get("label"))
+            p.setdefault("text", text)
+            eval_res = self.infer.evaluate_scheme(p)
+            evaluations.append(
+                {
+                    "scheme": eval_res.scheme,
+                    "confidence": eval_res.confidence,
+                    "requirements": [
+                        {
+                            "name": r.requirement.name,
+                            "satisfied": r.satisfied,
+                            "score": r.score,
+                            "missing_premise": r.missing_premise,
+                        }
+                        for r in eval_res.requirements
+                    ],
+                }
+            )
+            assumptions.extend(eval_res.generated_assumptions)
+        return {"evaluations": evaluations, "assumptions": assumptions}
 
     # Stage 4: Dynamic Probe Orchestration
     def stage4_probes(self, context: AnalysisContext, patterns: List[Dict[str, Any]]) -> Dict[str, Any]:
         initial = {"patterns": patterns, "forum": context.forum, "audience": context.audience, "goal": context.goal}
-        chain = self.probes.chain_probes_conditionally(initial)
+        chain = self.probes.chain_probes_conditionally(initial, profile=self.profile)
         return {"probe_plan": chain}
 
     # Stage 5: Integration and Validation
-    def stage5_integrate(self, text: str, nodes: List[Dict[str, Any]], links: List[Dict[str, Any]], patterns: List[Dict[str, Any]], assumptions: List[Dict[str, Any]]) -> Dict[str, Any]:
-        # Build light validation and narrative
-        issues = self._validate_graph(nodes, links)
-        narrative = self._build_narrative(text, nodes, patterns, assumptions)
-        return {"validation": issues, "narrative": narrative}
+    def stage5_integrate(self, text: str, nodes: List[Dict[str, Any]], links: List[Dict[str, Any]], patterns: List[Dict[str, Any]], infer_res: Dict[str, Any]) -> Dict[str, Any]:
+        graph = ArgumentGraph()
+        for n in nodes:
+            graph.add_node(ArgumentNode.from_dict(n))
+        for l in links:
+            graph.add_edge(ArgumentLink.from_dict(l))
+        for asm in infer_res["assumptions"]:
+            a_node = ArgumentNode.make("STATEMENT", content=asm, primary_subtype="Assumption")
+            graph.add_node(a_node)
+        structure_issues = graph.validate_structure()
+        claims = [n.get("content", "") for n in nodes]
+        conflicts = check_factual_consistency(claims)
+        senti_issues = check_sentiment_coherence(claims)
+        plaus = [check_plausibility(a) for a in infer_res["assumptions"]]
+        narrative = self._build_narrative(text, nodes, patterns, [{"text": a} for a in infer_res["assumptions"]])
+        return {
+            "graph": graph.to_json(),
+            "validation": {
+                "structure": structure_issues,
+                "contradictions": conflicts,
+                "sentiment_mismatch": senti_issues,
+                "plausibility": plaus,
+            },
+            "narrative": narrative,
+        }
 
     # Public API
-    def analyze_comprehensive(self, text: str, context: AnalysisContext) -> Dict[str, Any]:
+    def _run_once(self, text: str, context: AnalysisContext) -> Dict[str, Any]:
+        self.profile = PROFILES.get(context.forum or "general", PROFILES["general"])
+        self.infer.profile = self.profile
         s1 = self.stage1_decompose(text)
-        s2 = self.stage2_patterns(text, s1["nodes"])  # nodes annotated
-        s3 = self.stage3_gaps(s2["patterns"], s2["nodes"])  # nodes with assumptions
-        s4 = self.stage4_probes(context, s2["patterns"])  # probe plan
-        s5 = self.stage5_integrate(text, s3["nodes"], s1["links"], s2["patterns"], s3["assumptions"])  # validation + narrative
+        s2 = self.stage2_patterns(text, s1["nodes"])
+        s3 = self.stage3_infer(text, s2["patterns"])
+        s4 = self.stage4_probes(context, s2["patterns"])
+        s5 = self.stage5_integrate(text, s2["nodes"], s1["links"], s2["patterns"], s3)
         return {
             "context": asdict(context),
-            "structure": {"nodes": s3["nodes"], "links": s1["links"]},
+            "structure": {"nodes": s2["nodes"], "links": s1["links"]},
             "patterns": s2["patterns"],
+            "evaluations": s3["evaluations"],
             "assumptions": s3["assumptions"],
             "probes": s4["probe_plan"],
             "integration": s5,
         }
+
+    def cross_validate_stages(self, analysis: Dict[str, Any]) -> Dict[str, Any]:
+        pattern_types = {p.get("pattern_type") for p in analysis.get("patterns", [])}
+        nodes = analysis.get("structure", {}).get("nodes", [])
+        unmatched = []
+        for pt in pattern_types:
+            if not any(pt.lower() in ((n.get("reasoning_pattern") or "").lower()) for n in nodes):
+                unmatched.append(pt)
+        return {"needs_refinement": bool(unmatched), "unmatched_patterns": unmatched}
+
+    def refine_analysis(self, analysis: Dict[str, Any], validation: Dict[str, Any]) -> Dict[str, Any]:
+        nodes = analysis.get("structure", {}).get("nodes", [])
+        main = next((n for n in nodes if n.get("primary_subtype") == "Main Claim"), None)
+        if main:
+            for pt in validation.get("unmatched_patterns", []):
+                if not main.get("reasoning_pattern"):
+                    main["reasoning_pattern"] = pt.title()
+        return analysis
+
+    def analyze_comprehensive(self, text: str, context: AnalysisContext, max_iterations: int = 2) -> Dict[str, Any]:
+        analysis = self._run_once(text, context)
+        iteration = 0
+        while iteration < max_iterations:
+            validation = self.cross_validate_stages(analysis)
+            if not validation.get("needs_refinement"):
+                break
+            analysis = self.refine_analysis(analysis, validation)
+            iteration += 1
+        return analysis
 
     # Utilities
     def _split_sentences(self, text: str) -> List[str]:
@@ -168,6 +232,7 @@ class AnalysisEngine:
         if assumptions:
             lines.append("Key Assumptions:")
             for a in assumptions[:6]:
-                lines.append(f"- {a['text']} ({a['category']})")
+                cat = a.get('category', '')
+                lines.append(f"- {a['text']}" + (f" ({cat})" if cat else ""))
         return "\n".join(lines)
 

--- a/MCP_example_template/arg_mcp/engine.py
+++ b/MCP_example_template/arg_mcp/engine.py
@@ -30,6 +30,8 @@ class AnalysisEngine:
         self.probes = ProbeOrchestrator(tools)
         self.profile: DomainProfile = PROFILES["general"]
         self.infer = InferenceEngine(ontology, self.profile)
+        # backward compatibility: expose inference engine as 'gap'
+        self.gap = self.infer
 
     # Stage 1: Structural Decomposition
     def stage1_decompose(self, text: str) -> Dict[str, Any]:

--- a/MCP_example_template/arg_mcp/gap.py
+++ b/MCP_example_template/arg_mcp/gap.py
@@ -22,6 +22,15 @@ class RequirementResult:
     missing_premise: Optional[str] = None
 
 
+@dataclass
+class MissingAssumption:
+    """Legacy container for backward compatibility."""
+    text: str
+    category: str
+    rationale: str
+    priority: str  # critical, testable, controversial, other
+
+
 RequirementCheck = Callable[[str, Dict[str, str]], RequirementResult]
 
 
@@ -116,5 +125,4 @@ class InferenceEngine:
 
 
 # Backwards compatibility exports
-RequirementResult = RequirementResult
-InferenceEngine = InferenceEngine
+GapAnalyzer = InferenceEngine

--- a/MCP_example_template/arg_mcp/patterns.py
+++ b/MCP_example_template/arg_mcp/patterns.py
@@ -2,50 +2,87 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Any, Tuple
-import re
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from .ontology import Ontology, OntologyRow
 
 
 @dataclass
 class Pattern:
     pattern_id: str
-    pattern_type: str  # causal, authority, analogical, normative, quantifier, temporal, statistical, definition
+    pattern_type: str  # causal, authority, analogical, normative, etc.
     label: str
     span: Optional[Tuple[int, int]]
     confidence: float
     details: Dict[str, Any]
+    roles: Dict[str, str] = None
 
 
-class PatternDetector:
-    def __init__(self) -> None:
-        # Compile regex for core patterns with some paraphrase coverage
-        self.re_causal = re.compile(r"\b(because|since|leads to|results in|due to|therefore|thus|so that|causes?)\b", re.I)
-        self.re_authority = re.compile(r"\b(experts? (say|agree)|studies? (show|find)|researchers?|doctor|dr\.|prof(essor)?|according to)\b", re.I)
-        self.re_analogical = re.compile(r"\b(like|similar to|analog(ous)?|as if|just as)\b", re.I)
-        self.re_normative = re.compile(r"\b(should|ought to|must|need to|the best way|we should)\b", re.I)
-        self.re_quantifier = re.compile(r"\b(always|never|everyone|no one|all|none|most|many|few)\b", re.I)
-        self.re_temporal = re.compile(r"\b(before|after|until|while|prior to|subsequently|eventually|now)\b", re.I)
-        self.re_statistical = re.compile(r"\b(percent|%|p-value|statistical(ly)? significant|correlat(es|ion)|regression|sample|random|control group)\b", re.I)
-        self.re_definition = re.compile(r"\b(defines? as|means that|by definition|we call|is defined as)\b", re.I)
+class EnhancedPatternDetector:
+    """Semantic pattern detector using ontology descriptions instead of regex."""
 
-    def _scan(self, text: str, kind: str, regex: re.Pattern, label: str) -> List[Pattern]:
-        out: List[Pattern] = []
-        for m in regex.finditer(text):
-            conf = 0.7
-            if kind in ("quantifier", "temporal"):
-                conf = 0.5
-            out.append(Pattern(pattern_id=f"pat_{m.start()}_{m.end()}", pattern_type=kind, label=label, span=(m.start(), m.end()), confidence=conf, details={"match": m.group(0)}))
-        return out
+    def __init__(self, ontology: Ontology) -> None:
+        self.ontology = ontology
+        self.scheme_rows: List[OntologyRow] = [r for r in ontology.rows if r.dimension == "Argument Scheme"]
+        corpus = [" ".join([r.category, r.bucket, r.description, r.example]) for r in self.scheme_rows]
+        if corpus:
+            self.vectorizer = TfidfVectorizer().fit(corpus)
+            self.matrix = self.vectorizer.transform(corpus)
+        else:
+            self.vectorizer = TfidfVectorizer().fit([""])
+            self.matrix = self.vectorizer.transform([""])
+
+    def _map_pattern_type(self, row: OntologyRow) -> str:
+        cat = f"{row.category} {row.bucket}".lower()
+        if "cause" in cat or "consequence" in cat:
+            return "causal"
+        if "expert" in cat or "authority" in cat or "testimony" in cat:
+            return "authority"
+        if "analog" in cat:
+            return "analogical"
+        if "practical" in cat or "policy" in cat:
+            return "normative"
+        return "other"
 
     def detect(self, text: str) -> List[Pattern]:
-        L = text
-        pats: List[Pattern] = []
-        pats += self._scan(L, "causal", self.re_causal, "Causal Indicator")
-        pats += self._scan(L, "authority", self.re_authority, "Authority Marker")
-        pats += self._scan(L, "analogical", self.re_analogical, "Analogical Language")
-        pats += self._scan(L, "normative", self.re_normative, "Normative/Practical")
-        pats += self._scan(L, "quantifier", self.re_quantifier, "Quantifier/Generality")
-        pats += self._scan(L, "temporal", self.re_temporal, "Temporal Cue")
-        pats += self._scan(L, "statistical", self.re_statistical, "Statistical/Evidence Cue")
-        pats += self._scan(L, "definition", self.re_definition, "Definition/Category Cue")
-        return pats
+        if not text.strip():
+            return []
+        vec = self.vectorizer.transform([text])
+        sims = cosine_similarity(vec, self.matrix)[0]
+        out: List[Pattern] = []
+        for i, score in enumerate(sims):
+            if score <= 0:
+                continue
+            row = self.scheme_rows[i]
+            ptype = self._map_pattern_type(row)
+            roles: Dict[str, str] = {}
+            if ptype == "causal":
+                if "because" in text:
+                    parts = text.split("because", 1)
+                    roles = {"effect": parts[0].strip(), "cause": parts[1].strip()}
+                elif "leads to" in text:
+                    parts = text.split("leads to", 1)
+                    roles = {"cause": parts[0].strip(), "effect": parts[1].strip()}
+            if ptype == "analogical" and " like " in text:
+                parts = text.split(" like ", 1)
+                roles = {"target": parts[0].strip(), "base": parts[1].strip()}
+            out.append(
+                Pattern(
+                    pattern_id=f"scheme_{i}",
+                    pattern_type=ptype,
+                    label=row.category,
+                    span=None,
+                    confidence=float(score),
+                    details={"scheme": row.category, "score": float(score)},
+                    roles=roles,
+                )
+            )
+        out.sort(key=lambda p: p.confidence, reverse=True)
+        return out[:10]
+
+
+# Backwards compatibility export
+PatternDetector = EnhancedPatternDetector
 

--- a/MCP_example_template/arg_mcp/structures.py
+++ b/MCP_example_template/arg_mcp/structures.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, asdict
 from typing import List, Optional, Tuple, Dict, Any
+
+from .ontology import Ontology
 import uuid
 
 
@@ -127,3 +129,69 @@ class ArgumentLink:
             issues.append("confidence must be in [0,1]")
         return issues
 
+
+class NodePropertyAssigner:
+    """Assign ontology-informed properties across multiple dimensions to nodes."""
+
+    def __init__(self, ontology: Ontology) -> None:
+        self.ontology = ontology
+
+    def assign_comprehensive_properties(
+        self, node: Dict[str, Any], text_context: str, detected_patterns: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        dims = {
+            "claim_type": "Claim Type",
+            "evidence_type": "Evidence Type",
+            "reasoning_pattern": "Reasoning Pattern",
+            "cognitive_biases": "Cognitive Bias",
+            "fallacy_indicators": "Fallacy",
+        }
+        content = node.get("content", "")
+        for field, dim in dims.items():
+            res = self.ontology.semantic_search(content, dimensions=[dim], threshold=0.15, max_results=1)
+            if not res:
+                continue
+            bucket = res[0]["bucket"]
+            if field in ("cognitive_biases", "fallacy_indicators"):
+                node.setdefault(field, [])
+                if bucket not in node[field]:
+                    node[field].append(bucket)
+            else:
+                node[field] = bucket
+
+        # incorporate detected patterns as reasoning hints
+        if detected_patterns:
+            for p in detected_patterns:
+                if p.get("pattern_type") == "normative":
+                    node.setdefault("reasoning_pattern", "Practical Reasoning")
+                if p.get("pattern_type") == "causal":
+                    node.setdefault("reasoning_pattern", "Causal")
+
+        return node
+
+
+
+@dataclass
+class ArgumentGraph:
+    nodes: Dict[str, ArgumentNode] = field(default_factory=dict)
+    edges: List[ArgumentLink] = field(default_factory=list)
+
+    def add_node(self, node: ArgumentNode) -> None:
+        self.nodes[node.node_id] = node
+
+    def add_edge(self, edge: ArgumentLink) -> None:
+        self.edges.append(edge)
+
+    def validate_structure(self) -> List[str]:
+        issues: List[str] = []
+        ids = set(self.nodes)
+        for e in self.edges:
+            if e.source_node not in ids or e.target_node not in ids:
+                issues.append(f"dangling edge {e.link_id}")
+        return issues
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "nodes": [n.to_dict() for n in self.nodes.values()],
+            "edges": [e.to_dict() for e in self.edges],
+        }

--- a/MCP_example_template/arg_mcp/validation.py
+++ b/MCP_example_template/arg_mcp/validation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Lightweight validation utilities for argument analysis."""
+
+from typing import List, Dict, Tuple
+
+_POSITIVE = {"good", "beneficial", "positive", "improve", "support"}
+_NEGATIVE = {"bad", "harm", "negative", "worsen", "oppose"}
+_ABSURD = {"square circle", "perpetual motion machine", "humans breathe water"}
+
+
+def check_factual_consistency(claims: List[str]) -> List[Tuple[str, str]]:
+    """Detect contradictions when one sentence negates another."""
+    conflicts: List[Tuple[str, str]] = []
+    norm = [c.lower().strip() for c in claims]
+    for i, a in enumerate(norm):
+        for j, b in enumerate(norm):
+            if i >= j:
+                continue
+            if a.replace("not ", "") == b and (" not " in a or " not " in b):
+                conflicts.append((claims[i], claims[j]))
+    return conflicts
+
+
+def check_sentiment_coherence(segments: List[str]) -> List[int]:
+    """Return indices of segments whose sentiment conflicts with majority."""
+    scores = []
+    for seg in segments:
+        tokens = set(seg.lower().split())
+        pos = len(tokens & _POSITIVE)
+        neg = len(tokens & _NEGATIVE)
+        scores.append(pos - neg)
+    avg = sum(scores) / len(scores) if scores else 0
+    issues = [i for i, s in enumerate(scores) if (s > 0 and avg < 0) or (s < 0 and avg > 0)]
+    return issues
+
+
+def check_plausibility(assertion: str) -> Tuple[float, str]:
+    """Naive plausibility check using an absurd phrase list."""
+    low = any(p in assertion.lower() for p in _ABSURD)
+    return (0.1, "contains absurd phrase") if low else (0.9, "plausible")

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This repository contains a sophisticated FastMCP server implementation that prov
 │   │   ├── patterns.py          # Pattern detection algorithms
 │   │   ├── structures.py        # Argument structure analysis
 │   │   ├── probes.py            # Diagnostic probe tools
-│   │   └── gap.py               # Gap analysis and assumptions
+│   │   ├── gap.py               # Dynamic inference engine for gaps
+│   │   ├── domain_profiles.py   # Domain adaptation profiles
+│   │   └── validation.py        # Factual, sentiment, plausibility checks
 │   └── FastMCP_Quickstart_Example.md  # Detailed documentation
 ├── argument_tools.csv            # Diagnostic probe tools catalog
 ├── new_argumentation_database_buckets_fixed.csv  # Ontology database
@@ -31,8 +33,10 @@ This repository contains a sophisticated FastMCP server implementation that prov
 
 - **Comprehensive Analysis**: Multi-stage argument breakdown with structured graph generation
 - **Pattern Detection**: Advanced detection of causal, authority, analogical, and other reasoning patterns
-- **Gap Analysis**: Systematic identification of missing assumptions and logical gaps
+- **Gap Analysis**: Dynamic inference rule checks generating scheme-specific missing premises
 - **Quality Assessment**: Framework-based evaluation of argument strengths and weaknesses
+- **Domain Adaptation**: Legal, scientific, policy profiles that adjust requirement weighting
+- **Validation**: Contradiction, sentiment, and plausibility checks for claims and assumptions
 - **Counter-Analysis**: Generation of counter-argument scaffolds and alternative perspectives
 
 ### Ontology Management

--- a/tests/test_domain_profile.py
+++ b/tests/test_domain_profile.py
@@ -1,0 +1,24 @@
+import unittest
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from MCP_example_template.arg_mcp.domain_profiles import PROFILES
+from MCP_example_template.arg_mcp.gap import InferenceEngine
+from MCP_example_template.arg_mcp.ontology import Ontology, load_ontology
+
+onto = Ontology(load_ontology('new_argumentation_database_buckets_fixed.csv'))
+
+class TestDomainProfiles(unittest.TestCase):
+    def test_scientific_extra_requirement(self):
+        engine = InferenceEngine(onto, PROFILES['scientific'])
+        candidate = {
+            'scheme': 'Argument from Cause to Effect',
+            'text': 'Study shows X leads to Y',
+            'roles': {'cause': 'X', 'effect': 'Y'},
+            'scheme_key': 'causal'
+        }
+        res = engine.evaluate_scheme(candidate)
+        names = [r.requirement.name for r in res.requirements]
+        self.assertIn('statistical_power', names)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_gap.py
+++ b/tests/test_gap.py
@@ -1,0 +1,25 @@
+import unittest
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from MCP_example_template.arg_mcp.gap import InferenceEngine
+from MCP_example_template.arg_mcp.ontology import Ontology, load_ontology
+from MCP_example_template.arg_mcp.domain_profiles import PROFILES
+
+# load small ontology from CSV
+onto = Ontology(load_ontology('new_argumentation_database_buckets_fixed.csv'))
+
+class TestInferenceEngine(unittest.TestCase):
+    def test_causal_temporal_requirement(self):
+        engine = InferenceEngine(onto, PROFILES['general'])
+        candidate = {
+            'scheme': 'Argument from Cause to Effect',
+            'text': 'Smoking causes cancer.',
+            'roles': {'cause': 'Smoking', 'effect': 'cancer'}
+        }
+        res = engine.evaluate_scheme(candidate)
+        names = [r.requirement.name for r in res.requirements if not r.satisfied]
+        self.assertIn('temporal_order', names)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add domain profiles and load them into analysis workflow for legal, scientific, policy, and general contexts
- replace static gap templates with requirement-driven inference engine
- integrate validation checks and argument graph construction in engine

## Testing
- `pytest tests/test_gap.py tests/test_domain_profile.py -q`
- `python - <<'PY'
from MCP_example_template.arg_mcp import load_ontology, Ontology, load_tool_catalog, ToolCatalog, AnalysisEngine, AnalysisContext
import os
workdir='.'
onto=Ontology(load_ontology(os.path.join(workdir,'new_argumentation_database_buckets_fixed.csv')))
tools=ToolCatalog(load_tool_catalog(os.path.join(workdir,'argument_tools.csv')))
engine=AnalysisEngine(onto, tools)
text="Experts say that smoking causes cancer because studies show strong evidence. Therefore, governments should regulate tobacco."
res=engine.analyze_comprehensive(text, AnalysisContext(forum='policy'))
print('Patterns count', len(res['patterns']))
print('Assumptions', res['assumptions'][:2])
print('Graph nodes', len(res['integration']['graph']['nodes']))
print('Validation keys', list(res['integration']['validation'].keys()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c5e9677828832d9bee7f24f21db27b